### PR TITLE
Replace use of dependency-recommender with gradle experimental features

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,10 +20,9 @@ plugins {
     id 'nebula.ivy-publish' version '5.1.5'
     id 'nebula.javadoc-jar' version '5.1.5'
     id 'nebula.source-jar' version '5.1.5'
-    
+
     id 'nebula.override' version '3.0.2'
     id 'nebula.optional-base' version '3.2.0'
-    id 'nebula.dependency-recommender' version '5.0.0'
     id 'nebula.resolution-rules' version '5.0.2'
     id 'nebula.dependency-lock' version '4.9.5'
 }
@@ -47,7 +46,7 @@ configurations.all {
 }
 
 dependencies {
-    nebulaRecommenderBom 'example.nebula:bom:1.+@pom'
+    compile 'example.nebula:bom:1.+'
     resolutionRules 'example.nebula:rules:1.+'
 
     implementation 'alignmentrule:b0:1.+'

--- a/override_project_example/build.gradle
+++ b/override_project_example/build.gradle
@@ -42,7 +42,7 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 
 dependencyRecommendations {
     strategy OverrideTransitives
-    map recommendations: ['overridestrategy:transitivedeb': '1.0.0']
+    map recommendations: ['overridestrategy:transitivedeb': '1.0.1']
 }
 
 dependencies {

--- a/override_project_example/build.gradle
+++ b/override_project_example/build.gradle
@@ -23,7 +23,6 @@ plugins {
 
     id 'nebula.override' version '3.0.2'
     id 'nebula.optional-base' version '3.2.0'
-    id 'nebula.dependency-recommender' version '5.0.0'
     id 'nebula.resolution-rules' version '5.0.2'
     id 'nebula.dependency-lock' version '4.9.5'
 }
@@ -40,11 +39,9 @@ repositories {
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 
-dependencyRecommendations {
-    strategy OverrideTransitives
-    map recommendations: ['overridestrategy:transitivedeb': '1.0.1']
-}
-
 dependencies {
     compile 'overridestrategy:a:1.0.0'
+    constraints {
+        compile 'overridestrategy:transitivedeb:1.0.1'
+    }
 }

--- a/override_project_example/settings.gradle
+++ b/override_project_example/settings.gradle
@@ -1,0 +1,4 @@
+rootProject.name = 'recommender-override'
+
+gradle.experimentalFeatures.enable()
+

--- a/repository/maven/example/nebula/bom/1.0.0/bom-1.0.0.pom
+++ b/repository/maven/example/nebula/bom/1.0.0/bom-1.0.0.pom
@@ -4,6 +4,7 @@
   <groupId>example.nebula</groupId>
   <artifactId>bom</artifactId>
   <version>1.0.0</version>
+  <packaging>pom</packaging>
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/repository/maven/overridestrategy/a/1.0.0/a-1.0.0.pom
+++ b/repository/maven/overridestrategy/a/1.0.0/a-1.0.0.pom
@@ -9,7 +9,7 @@
     <dependency>
       <groupId>overridestrategy</groupId>
       <artifactId>transitivedeb</artifactId>
-      <version>1.0.1</version>
+      <version>1.0.0</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,3 +6,5 @@ pluginManagement {
 }
 
 rootProject.name = 'example-project'
+
+gradle.experimentalFeatures.enable()


### PR DESCRIPTION
For your perusal: these changes demonstrate the use of 'dependency constraints' in Gradle to replace the use of the `nebula.dependency-recommender` plugin.